### PR TITLE
Fallback to below cursor when there's not enough space above

### DIFF
--- a/denops/signature_help/config.ts
+++ b/denops/signature_help/config.ts
@@ -13,6 +13,7 @@ export type Config = {
   style: signatureStyle;
   onTriggerChar: boolean;
   multiLabel: boolean;
+  fallbackToBelow: boolean;
 };
 
 export function getDefaultDocConfig(): Config {
@@ -24,6 +25,7 @@ export function getDefaultDocConfig(): Config {
     style: "full",
     onTriggerChar: false,
     multiLabel: false,
+    fallbackToBelow: true,
   };
 }
 

--- a/denops/signature_help/signature.ts
+++ b/denops/signature_help/signature.ts
@@ -172,7 +172,8 @@ export class SigHandler {
       config.maxWidth,
     );
     // If screenrow is too small, show signature help below the line.
-    const fallbackToBelow = screenrow - 1 <= (config.border ? 2 : 0);
+    const fallbackToBelow =
+      config.fallbackToBelow && screenrow - 1 <= (config.border ? 2 : 0);
     const maxHeight = Math.min(
       fallbackToBelow ? screenHeight - screenrow : screenrow - 1,
       config.maxHeight

--- a/denops/signature_help/signature.ts
+++ b/denops/signature_help/signature.ts
@@ -1,4 +1,4 @@
-import { Denops, fn, op } from "./deps.ts";
+import { Denops, fn, op, vars } from "./deps.ts";
 import { FloatOption, SignatureHelp } from "./types.ts";
 import { Config } from "./config.ts";
 import { requestSignatureHelp } from "./integ.ts";
@@ -166,11 +166,21 @@ export class SigHandler {
     this.prevItem = help;
 
     const screenrow = await fn.screenrow(denops) as number;
+    const screenHeight = await vars.options.get(denops, "lines", 0);
     const maxWidth = Math.min(
       await op.columns.get(denops),
       config.maxWidth,
     );
-    const maxHeight = Math.min(screenrow - 1, config.maxHeight);
+    // If screenrow is too small, show signature help below the line.
+    const fallbackToBelow = screenrow - 1 <= (config.border ? 2 : 0);
+    const maxHeight = Math.min(
+      fallbackToBelow ? screenHeight - screenrow : screenrow - 1,
+      config.maxHeight
+    );
+    if (maxHeight <= (config.border ? 2 : 0)) {
+      // The screen is too small, give up to show floating window.
+      return;
+    }
     const col = config.style == "currentLabelOnly"
       ? 0
       : await this.calcWinPos(denops, help);
@@ -183,8 +193,12 @@ export class SigHandler {
       border: config.border,
     });
 
+    const row = fallbackToBelow
+      ? screenrow + 1
+      : screenrow - hiCtx.height - (config.border ? 2 : 0);
+
     const floatingOpt: FloatOption = {
-      row: screenrow - hiCtx.height - (config.border ? 2 : 0),
+      row: row,
       col: col + (await fn.screencol(denops) as number),
       border: config.border,
       height: hiCtx.height,

--- a/doc/signature_help.txt
+++ b/doc/signature_help.txt
@@ -130,6 +130,12 @@ multiLabel 			*denops-signature_help-option-multiLabel*
 		|denops-signature_help-option-style| is "full" or "labelOnly".
 		(default: v:false)
 
+fallbackToBelow			*denops-signature_help-option-fallbackToBelow*
+		If it is true, the floating window opens below the cursor if
+		there is not enough space above the cursor; If false, floating
+		window doesn't open in such cases.
+		(default: v:true)
+
 ==============================================================================
 EXAMPLE					*denops-signature_help-example*
 This is the default config.
@@ -141,6 +147,7 @@ This is the default config.
 	      \ 'style': "full",
 	      \ 'onTriggerChar': v:false,
 	      \ 'multiLabel': v:false,
+	      \ 'fallbackToBelow': v:true,
 	      \ }
 >
 ==============================================================================


### PR DESCRIPTION
Currently triggering signature help in the very top line on the screen causes the following error:
(E5555: API call: 'height' key must be a positive Integer)

![image](https://user-images.githubusercontent.com/20490597/169902329-8e3a7384-c4b8-4898-9663-26d0ab0cb903.png)

To solve the issue, open floating window below the cursor when there's not enough space above. For users who don't let the floating window shown below, I made this behavior configurable.