### PR TITLE
Suppress errors when signatureHelp is null

### DIFF
--- a/denops/signature_help/markdown.ts
+++ b/denops/signature_help/markdown.ts
@@ -75,7 +75,7 @@ export function convertSignatureHelpToMarkdownLines(
   style: signatureStyle,
   multiLabel = false,
 ): [string[], [number, number] | null] | null {
-  if (!signatureHelp.signatures) return null;
+  if (!signatureHelp?.signatures) return null;
   let activeHl: [number, number] = [0, 0];
   let activeSignature = (signatureHelp.activeSignature || 0);
   if (


### PR DESCRIPTION
Simple fix for an annoying problem...

Seems to be Vim and `vim-lsp` specific, but this plugin throws frequent errors when editing files. Error checking `signatureHelp` before use stops these errors, but shouldn't negatively affect the plugin in general use. The plugin is not broken, it's just not finding anything to provide help for. Using the plugin in Neovim with the built-in LSP client hasn't produced the same error.

An example of the error is here:
![Screenshot 2022-06-06 at 19 19 28](https://user-images.githubusercontent.com/47668096/172222256-cfaf9bc9-865d-4b39-8d09-7d15c80e0fb4.png)

