### PR TITLE
Update denops v4 to v5

### DIFF
--- a/denops/signature_help/deps.ts
+++ b/denops/signature_help/deps.ts
@@ -10,4 +10,3 @@ export * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 export * as autocmd from "https://deno.land/x/denops_std@v5.0.1/autocmd/mod.ts";
 export { assertEquals } from "https://deno.land/std@0.173.0/testing/asserts.ts";
 export * as log from "https://deno.land/std@0.173.0/log/mod.ts";
-export { isLike } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";

--- a/denops/signature_help/deps.ts
+++ b/denops/signature_help/deps.ts
@@ -1,13 +1,13 @@
-export type { Denops } from "https://deno.land/x/denops_std@v4.0.0/mod.ts";
+export type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 export {
   batch,
-  gather,
-} from "https://deno.land/x/denops_std@v4.0.0/batch/mod.ts";
-export * as op from "https://deno.land/x/denops_std@v4.0.0/option/mod.ts";
-export * as fn from "https://deno.land/x/denops_std@v4.0.0/function/mod.ts";
-export * as nvimFn from "https://deno.land/x/denops_std@v4.0.0/function/nvim/mod.ts";
-export * as vars from "https://deno.land/x/denops_std@v4.0.0/variable/mod.ts";
-export * as autocmd from "https://deno.land/x/denops_std@v4.0.0/autocmd/mod.ts";
+  collect,
+} from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
+export * as op from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+export * as fn from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
+export * as nvimFn from "https://deno.land/x/denops_std@v5.0.1/function/nvim/mod.ts";
+export * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
+export * as autocmd from "https://deno.land/x/denops_std@v5.0.1/autocmd/mod.ts";
 export { assertEquals } from "https://deno.land/std@0.173.0/testing/asserts.ts";
 export * as log from "https://deno.land/std@0.173.0/log/mod.ts";
 export { isLike } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";

--- a/denops/signature_help/deps.ts
+++ b/denops/signature_help/deps.ts
@@ -8,5 +8,5 @@ export * as fn from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 export * as nvimFn from "https://deno.land/x/denops_std@v5.0.1/function/nvim/mod.ts";
 export * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 export * as autocmd from "https://deno.land/x/denops_std@v5.0.1/autocmd/mod.ts";
-export { assertEquals } from "https://deno.land/std@0.173.0/testing/asserts.ts";
-export * as log from "https://deno.land/std@0.173.0/log/mod.ts";
+export { assertEquals } from "https://deno.land/std@0.198.0/testing/asserts.ts";
+export * as log from "https://deno.land/std@0.198.0/log/mod.ts";

--- a/denops/signature_help/integ.ts
+++ b/denops/signature_help/integ.ts
@@ -1,4 +1,4 @@
-import { Denops, fn, gather } from "./deps.ts";
+import { collect, Denops, fn } from "./deps.ts";
 import { ServerCapabilities } from "./types.ts";
 
 let lspType: "vimlsp" | "nvimlsp" | null;
@@ -10,14 +10,13 @@ export async function getServerCapabilities(
     const servers = await denops.call("lsp#get_allowed_servers") as string[];
     if (servers.length) {
       lspType = "vimlsp";
-      return await gather(denops, async (denops) => {
-        for (const server of servers) {
-          await denops.call(
-            "lsp#get_server_capabilities",
-            server,
-          );
-        }
-      }) as ServerCapabilities[];
+      return await collect(
+        denops,
+        (denops) =>
+          servers.map((server) =>
+            denops.call("lsp#get_server_capabilities", server)
+          ),
+      ) as ServerCapabilities[];
     }
   }
   if (await fn.has(denops, "nvim")) {

--- a/denops/signature_help/markdown.ts
+++ b/denops/signature_help/markdown.ts
@@ -1,4 +1,4 @@
-import { Denops, fn, gather, vars } from "./deps.ts";
+import { collect, Denops, fn, vars } from "./deps.ts";
 import { SignatureHelp } from "./types.ts";
 import { contentsStyle } from "./config.ts";
 
@@ -194,11 +194,10 @@ export async function makeFloatingwinSize(
     maxWidth -= 2;
     maxHeight -= 2;
   }
-  const widths = await gather(denops, async (denops) => {
-    for (const line of lines) {
-      await fn.strdisplaywidth(denops, line);
-    }
-  }) as number[];
+  const widths = await collect(
+    denops,
+    (denops) => lines.map((line) => fn.strdisplaywidth(denops, line)),
+  ) as number[];
   const width = Math.min(Math.max(...widths), maxWidth);
 
   let height = 0;


### PR DESCRIPTION
I noticed this plugin uses denops_std v4, so I updated it to v5.