### PR TITLE
Replace deprecated api to new one

### DIFF
--- a/lua/signature_help/nvimlsp.lua
+++ b/lua/signature_help/nvimlsp.lua
@@ -25,7 +25,7 @@ end
 
 local get_capabilities = function()
   local caps = {}
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
+  for _, client in pairs(vim.lsp.get_clients({ bufnr = api.nvim_get_current_buf() })) do
     if client.server_capabilities then
       table.insert(caps, client.server_capabilities)
     end


### PR DESCRIPTION
`vim.lsp.buf_get_clients()` is deprecated. 